### PR TITLE
Start sharing piece downloads among peers for faster completion

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -587,9 +587,16 @@ arrives.
 
 ## Piece download
 
-A piece download tracks the piece completion of an ongoing piece download. It
-  will play an important role in optimizing download performance, but none of
-  that is implemented for now (see research notes).
+A piece download tracks the piece completion of an ongoing piece download.
+
+It plays an important role in optimizing download performance:
+- it plays a role in timing out peer requests
+- and (currently unimplemented) end game mode to speed up the last part of the
+  download.
+
+Piece downloads are stored in the torrent and shared with all peers in the
+torrent. When a peer starts a new download, it places the download instance in
+the shared torrent object. This way other peers may join this download.
 
 
 ## Disk IO

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -590,9 +590,12 @@ arrives.
 A piece download tracks the piece completion of an ongoing piece download.
 
 It plays an important role in optimizing download performance:
-- it plays a role in timing out peer requests
-- and (currently unimplemented) end game mode to speed up the last part of the
+- sharing block requests in piece among peers,
+- timing out peer requests,
+- and end game mode to speed up the last part of the
   download.
+
+Currently the last two are not implemented.
 
 Piece downloads are stored in the torrent and shared with all peers in the
 torrent. When a peer starts a new download, it places the download instance in

--- a/cratetorrent/src/disk/io.rs
+++ b/cratetorrent/src/disk/io.rs
@@ -65,13 +65,17 @@ impl Disk {
     pub(super) async fn start(&mut self) -> Result<()> {
         log::info!("Starting disk IO event loop");
         while let Some(cmd) = self.cmd_port.recv().await {
-            log::debug!("Disk received command");
             match cmd {
                 Command::NewTorrent {
                     id,
                     info,
                     piece_hashes,
                 } => {
+                    log::trace!(
+                        "Disk received NewTorrent command: id={}, info={:?}",
+                        id,
+                        info
+                    );
                     if self.torrents.contains_key(&id) {
                         log::warn!("Torrent {} already allocated", id);
                         self.alert_chan.send(Alert::TorrentAllocation(Err(

--- a/cratetorrent/src/download.rs
+++ b/cratetorrent/src/download.rs
@@ -42,7 +42,7 @@ impl PieceDownload {
     /// Picks the requested number of blocks or fewer, if fewer are remaining.
     pub fn pick_blocks(&mut self, count: usize, blocks: &mut Vec<BlockInfo>) {
         log::trace!(
-            "Picking {} block(s) in piece {} (length: {}, blocks: {})",
+            "Trying to pick {} block(s) in piece {} (length: {}, blocks: {})",
             count,
             self.index,
             self.len,
@@ -73,14 +73,14 @@ impl PieceDownload {
         }
 
         if picked > 0 {
-            log::debug!(
+            log::trace!(
                 "Picked {} block(s) for piece {}: {:?}",
                 picked,
                 self.index,
                 &blocks[blocks.len() - picked..]
             );
         } else {
-            log::debug!("Cannot pick any blocks in piece {}", self.index);
+            log::trace!("Cannot pick any blocks in piece {}", self.index);
         }
     }
 

--- a/cratetorrent/src/peer.rs
+++ b/cratetorrent/src/peer.rs
@@ -262,7 +262,7 @@ impl PeerSession {
             let request_timeout = self.state.request_timeout();
             log::debug!(
                 "[Peer {}] Checking request timeout \
-                (req. {} ms ago, timeout: {} ms)",
+                (last {} ms ago, timeout: {} ms)",
                 self.addr,
                 elapsed_since_last_request.as_millis(),
                 request_timeout.as_millis()


### PR DESCRIPTION
Closes #45 and #48 

Tested on a 50 MiB download from 2 seeds (using `./test_multi_connection_download.sh --size $(( 50 * 1024 * 1024 ))` ):
- master: avg ~25s
- this patch: avg ~15s

~60% improvement in multi-peer downloads.