### PR TITLE
Update tokio-util to 0.3

### DIFF
--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -30,7 +30,7 @@ serde_derive = "1.0"
 sha-1 = "0.9"
 # TODO(#76): update tokio when reqwest also updates it
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-threaded", "stream", "sync", "tcp", "time"] }
-tokio-util = { version = "0.2", features = ["codec"] }
+tokio-util = { version = "0.3", features = ["codec"] }
 url = "2.2"
 
 [dev-dependencies]

--- a/cratetorrent/src/peer/codec.rs
+++ b/cratetorrent/src/peer/codec.rs
@@ -58,8 +58,7 @@ pub(crate) const PROTOCOL_STRING: &str = "BitTorrent protocol";
 /// receive and send buffers.
 pub(crate) struct HandshakeCodec;
 
-impl Encoder for HandshakeCodec {
-    type Item = Handshake;
+impl Encoder<Handshake> for HandshakeCodec {
     type Error = io::Error;
 
     fn encode(
@@ -284,13 +283,12 @@ impl BlockInfo {
 /// handshake).
 pub(crate) struct PeerCodec;
 
-impl Encoder for PeerCodec {
-    type Item = Message;
+impl Encoder<Message> for PeerCodec {
     type Error = io::Error;
 
     fn encode(
         &mut self,
-        msg: Self::Item,
+        msg: Message,
         buf: &mut BytesMut,
     ) -> io::Result<()> {
         use Message::*;


### PR DESCRIPTION
Currently, cratetorrent is compiling both tokio-util 0.2 and 0.3.

cc #76