### PR TITLE
Fix clap errors

### DIFF
--- a/cratetorrent-cli/src/main.rs
+++ b/cratetorrent-cli/src/main.rs
@@ -22,7 +22,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 pub struct Args {
     /// Whether to 'seed' or 'download' the torrent.
     #[structopt(
-        short, long,
+        long,
         parse(from_str = parse_mode),
         default_value = "Mode::Download { seeds: Vec::new() }",
     )]


### PR DESCRIPTION
`cratetorrent-cli` would panic at runtime with this error:
`thread 'main' panicked at 'Argument short must be unique`

this was because both the `mode` and `metainfo` options had an automatic `short` option generated for them and they both used `-m`. I've removed the short option from `mode`.

Closes #92 