### PR TITLE
Fallback to buffered IO disk operations when not on Linux

### DIFF
--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -20,7 +20,6 @@ hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 lru = "0.6"
-nix = "0.19"
 percent-encoding = "2.1"
 reqwest = "0.10"
 serde = "1.0"
@@ -32,6 +31,10 @@ sha-1 = "0.9"
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-threaded", "stream", "sync", "tcp", "time"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 url = "2.2"
+cfg-if = "1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = "0.19"
 
 [dev-dependencies]
 mockito = "0.28"

--- a/cratetorrent/src/disk/error.rs
+++ b/cratetorrent/src/disk/error.rs
@@ -46,6 +46,12 @@ pub(crate) enum WriteError {
     Io(std::io::Error),
 }
 
+impl From<std::io::Error> for WriteError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
 impl fmt::Display for WriteError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -70,6 +76,12 @@ pub(crate) enum ReadError {
     MissingData,
     /// An IO error ocurred.
     Io(std::io::Error),
+}
+
+impl From<std::io::Error> for ReadError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
 }
 
 impl fmt::Display for ReadError {

--- a/cratetorrent/src/lib.rs
+++ b/cratetorrent/src/lib.rs
@@ -6,10 +6,7 @@
 //!
 //! # Caveats
 //!
-//! The engine currently only supports Linux. This is expected to change in the
-//! future, however.
-//!
-//! It also lacks most features present in battle-hardened torrent engines, such
+//! The engine lacks most features present in battle-hardened torrent engines, such
 //! as [libtorrent](https://github.com/arvidn/libtorrent). These include: DHT
 //! for peer exchange, magnet links, stream encryption, UDP trackers, and many
 //! more.
@@ -156,7 +153,6 @@ mod disk;
 mod download;
 pub mod engine;
 pub mod error;
-pub mod iovecs;
 pub mod metainfo;
 pub mod peer;
 mod piece_picker;
@@ -164,6 +160,10 @@ pub mod prelude;
 pub mod storage_info;
 pub mod torrent;
 mod tracker;
+
+#[cfg(target_os = "linux")]
+pub mod iovecs;
+
 
 /// Each torrent gets a randomly assigned ID that is unique within the
 /// engine. This id is used in engine APIs to interact with torrents.


### PR DESCRIPTION
Closes #88 

I had to implement `read_exact_at/write_all_at`, and guess what? There's no cross platform API for `read_at/write_at`! For good reason: Unix API does not affect "seek cursor", while other's do. I don't think we care since we always specify the offset explicitly, but perhaps it's undesirable? Need your input, but I think we can live with that.

There are couple of code pieces gated under `cfg` which is quite ugly, but all attempts at factoring these pieces out resulted in pretentious versions of roughly the same code, so I decided this is good enough. Suggestions are welcome.

Overall, this is roughly the "working" version. "Working" because I haven't had a chance to test it. I'll proceed to it in two-three days (busy days, sorry),  so this is just me presenting the design for your judgement. 

(and a somewhat unrelated question: is `TorrentFile` really supposed be public? I just see all its methods are `pub` and have detailed doc comments, but the struct itself is `pub(crate)`)