### PR TITLE
Upgrade dependencies

### DIFF
--- a/cratetorrent-cli/Cargo.toml
+++ b/cratetorrent-cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 
 [dependencies]
 cratetorrent = { path = "../cratetorrent" }
-flexi_logger = "0.18.0"
-futures = "0.3.15"
-hex = "0.4.3"
-log = "0.4.14"
-structopt = "0.3.22"
-termion = "1.5.6"
-tokio = { version = "1.9.0", features = ["full"] }
-tui = "0.15.0"
+flexi_logger = "0.18"
+futures = "0.3"
+hex = "0.4"
+log = "0.4"
+structopt = "0.3"
+termion = "1.5"
+tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "io-std", "fs"] }
+tui = "0.15"

--- a/cratetorrent-cli/Cargo.toml
+++ b/cratetorrent-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratetorrent-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["mandreyel <mandreyel@protonmail.com>"]
 description = "A simple BitTorrent V1 CLI client"
 license = "MIT OR Apache-2.0"

--- a/cratetorrent-cli/Cargo.toml
+++ b/cratetorrent-cli/Cargo.toml
@@ -16,5 +16,5 @@ hex = "0.4"
 log = "0.4"
 structopt = "0.3"
 termion = "1.5"
-tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "io-std", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "fs"] }
 tui = "0.15"

--- a/cratetorrent-cli/Cargo.toml
+++ b/cratetorrent-cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 
 [dependencies]
 cratetorrent = { path = "../cratetorrent" }
-flexi_logger = "0.16"
-futures = "0.3"
-hex = "0.4"
-log = "0.4"
-structopt = "0.3"
-termion = "1.5"
-tokio = { version = "0.2", features = ["fs", "io-std", "macros", "rt-threaded"] }
-tui = "0.13"
+flexi_logger = "0.18.0"
+futures = "0.3.15"
+hex = "0.4.3"
+log = "0.4.14"
+structopt = "0.3.22"
+termion = "1.5.6"
+tokio = { version = "1.9.0", features = ["full"] }
+tui = "0.15.0"

--- a/cratetorrent-cli/src/app.rs
+++ b/cratetorrent-cli/src/app.rs
@@ -10,7 +10,6 @@ use cratetorrent::{
     torrent::stats::{Channel, Peers, PieceStats, Thruput, TorrentStats},
     FileInfo, TorrentId,
 };
-use futures::stream::{Fuse, StreamExt};
 
 use crate::{Args, Result};
 
@@ -18,7 +17,7 @@ use crate::{Args, Result};
 pub struct App {
     pub download_dir: PathBuf,
     pub engine: EngineHandle,
-    pub alert_rx: Fuse<AlertReceiver>,
+    pub alert_rx: AlertReceiver,
     pub torrents: HashMap<TorrentId, Torrent>,
 }
 
@@ -27,7 +26,6 @@ impl App {
         // start engine
         let conf = Conf::new(download_dir.clone());
         let (engine, alert_rx) = cratetorrent::engine::spawn(conf)?;
-        let alert_rx = alert_rx.fuse();
 
         Ok(Self {
             download_dir,

--- a/cratetorrent-cli/src/key.rs
+++ b/cratetorrent-cli/src/key.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use futures::stream::{Fuse, StreamExt};
 use termion::{event::Key, input::TermRead};
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver},
@@ -14,7 +13,7 @@ pub const EXIT_KEY: Key = Key::Char('q');
 /// used to drive the application.
 pub struct Keys {
     /// Input keys are sent to this channel.
-    pub rx: Fuse<UnboundedReceiver<Key>>,
+    pub rx: UnboundedReceiver<Key>,
 }
 
 impl Keys {
@@ -34,6 +33,6 @@ impl Keys {
                 }
             }
         });
-        Self { rx: rx.fuse() }
+        Self { rx }
     }
 }

--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -27,7 +27,7 @@ serde_bencode = "0.2"
 serde_bytes = "0.11"
 serde_derive = "1.0"
 sha-1 = "0.9"
-tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "sync", "net", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "net", "time"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 url = "2.2"
 

--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -14,24 +14,23 @@ edition = "2018"
 
 [dependencies]
 bitvec = "0.19"
-bytes = "1.0.1"
-futures = "0.3.15"
-hex = "0.4.3"
-log = "0.4.14"
-lru = "0.6.5"
-nix = "0.22.0"
-percent-encoding = "2.1.0"
-reqwest = "0.11.4"
-serde = "1.0.126"
-serde_bencode = "0.2.3"
-serde_bytes = "0.11.5"
-serde_derive = "1.0.126"
-sha-1 = "0.9.7"
-# TODO(#76): update tokio when reqwest also updates it
-tokio = { version = "1.9.0", features = ["full"] }
-tokio-util = { version = "0.6.7", features = ["codec"] }
-url = "2.2.2"
+bytes = "1.0"
+futures = "0.3"
+hex = "0.4"
+log = "0.4"
+lru = "0.6"
+nix = "0.22"
+percent-encoding = "2.1"
+reqwest = "0.11"
+serde = "1.0"
+serde_bencode = "0.2"
+serde_bytes = "0.11"
+serde_derive = "1.0"
+sha-1 = "0.9"
+tokio = { version = "1.9", features = ["macros", "rt-multi-thread", "sync", "net", "time"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+url = "2.2"
 
 [dev-dependencies]
-mockito = "0.30.0"
-pretty_assertions = "0.7.2"
+mockito = "0.30"
+pretty_assertions = "0.7"

--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -14,24 +14,24 @@ edition = "2018"
 
 [dependencies]
 bitvec = "0.19"
-bytes = "0.5"
-futures = "0.3"
-hex = "0.4"
-log = "0.4"
-lru = "0.6"
-nix = "0.19"
-percent-encoding = "2.1"
-reqwest = "0.10"
-serde = "1.0"
-serde_bencode = "0.2"
-serde_bytes = "0.11"
-serde_derive = "1.0"
-sha-1 = "0.9"
+bytes = "1.0.1"
+futures = "0.3.15"
+hex = "0.4.3"
+log = "0.4.14"
+lru = "0.6.5"
+nix = "0.22.0"
+percent-encoding = "2.1.0"
+reqwest = "0.11.4"
+serde = "1.0.126"
+serde_bencode = "0.2.3"
+serde_bytes = "0.11.5"
+serde_derive = "1.0.126"
+sha-1 = "0.9.7"
 # TODO(#76): update tokio when reqwest also updates it
-tokio = { version = "0.2", features = ["blocking", "macros", "rt-threaded", "stream", "sync", "tcp", "time"] }
-tokio-util = { version = "0.3", features = ["codec"] }
-url = "2.2"
+tokio = { version = "1.9.0", features = ["full"] }
+tokio-util = { version = "0.6.7", features = ["codec"] }
+url = "2.2.2"
 
 [dev-dependencies]
-mockito = "0.28"
-pretty_assertions = "0.6"
+mockito = "0.30.0"
+pretty_assertions = "0.7.2"

--- a/cratetorrent/Cargo.toml
+++ b/cratetorrent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratetorrent"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["mandreyel <mandreyel@protonmail.com>"]
 description = "A simple BitTorrent V1 engine library"
 license = "MIT OR Apache-2.0"

--- a/cratetorrent/src/engine.rs
+++ b/cratetorrent/src/engine.rs
@@ -19,7 +19,6 @@ use std::{
     net::{Ipv4Addr, SocketAddr},
 };
 
-use futures::stream::StreamExt;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
     task,
@@ -212,7 +211,7 @@ impl Engine {
     async fn run(&mut self) -> Result<()> {
         log::info!("Starting engine");
 
-        while let Some(cmd) = self.cmd_rx.next().await {
+        while let Some(cmd) = self.cmd_rx.recv().await {
             match cmd {
                 Command::CreateTorrent { id, params } => {
                     self.create_torrent(id, params).await?;

--- a/cratetorrent/src/lib.rs
+++ b/cratetorrent/src/lib.rs
@@ -92,7 +92,7 @@
 //!     })?;
 //!
 //!     // listen to alerts from the engine
-//!     while let Some(alert) = alert_rx.next().await {
+//!     while let Some(alert) = alert_rx.recv().await {
 //!         match alert {
 //!             Alert::TorrentStats { id, stats } => {
 //!                 println!("{}: {:#?}", id, stats);

--- a/cratetorrent/src/peer/codec.rs
+++ b/cratetorrent/src/peer/codec.rs
@@ -97,17 +97,6 @@ impl Decoder for HandshakeCodec {
             return Ok(None);
         }
 
-        // hack:
-        // `get_*` integer extractors consume the message bytes by advancing
-        // buf's internal cursor. However, we don't want to do this as at this
-        // point we aren't sure we have the full message in the buffer, and thus
-        // we just want to peek at this value.
-        //
-        // However, this is not supported by the `bytes` crate API
-        // (https://github.com/tokio-rs/bytes/issues/382), so we need to work
-        // this around by getting a reference to the underlying buffer and
-        // performing the message length extraction on the returned slice, which
-        // won't advance `buf`'s cursor
         let prot_len = if let Some(prot_len) = buf.first() {
             let prot_len = *prot_len as usize;
             if prot_len != PROTOCOL_STRING.as_bytes().len() {
@@ -417,17 +406,6 @@ impl Decoder for PeerCodec {
             return Ok(None);
         }
 
-        // hack:
-        // `get_*` integer extractors consume the message bytes by advancing
-        // buf's internal cursor. However, we don't want to do this as at this
-        // point we aren't sure we have the full message in the buffer, and thus
-        // we just want to peek at this value.
-        //
-        // However, this is not supported by the `bytes` crate API
-        // (https://github.com/tokio-rs/bytes/issues/382), so we need to work
-        // this around by getting a reference to the underlying buffer and
-        // performing the message length extraction on the returned slice, which
-        // won't advance `buf`'s cursor
         let msg_len = if let Some(len_bytes) = buf.get(0..4) {
             if len_bytes.len() < 4 {
                 return Ok(None);


### PR DESCRIPTION
Fixes #76 
Fixes #101 

Upgrade all dependencies (except `bitvec`). 

some not straightforward updates:
1. No need to use fused futures with `UnboundedReceiver` .
2. length reading code in `codec.rs` changed to use some extra apis provided in bytes 1.0 (tests work, but not sure if code can be improved further).